### PR TITLE
Add version 0.7 and make Makefile more automatic

### DIFF
--- a/0.7/Dockerfile
+++ b/0.7/Dockerfile
@@ -1,0 +1,7 @@
+FROM phpstan/phpstan:base
+MAINTAINER Tommy Muehle <tommy.muehle@gmail.com>
+
+ENV PHPSTAN_VERSION 0.7.x
+
+RUN composer global require phpstan/phpstan ^0.7 \
+    && composer global show | grep phpstan

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
-build: build-base build-0.6 build-latest
+VERSIONS := 0.6 0.7 latest
+BUILD_ALL_VERSIONS := $(addprefix build-, $(VERSIONS))
+TEST_ALL_VERSIONS := $(addprefix test-, $(VERSIONS))
 
-test: build test-0.6 test-latest
+all: test
 
+.PHONY: build build-base $(BUILD_ALL_VERSIONS)
 build-base:
 	docker build -t phpstan/phpstan:base base
 
-build-latest:
-	docker build -t phpstan/phpstan:latest latest
+$(BUILD_ALL_VERSIONS): build-%: build-base
+	docker build -t phpstan/phpstan:$* $*
 
-build-0.6:
-	docker build -t phpstan/phpstan:0.6 0.6
+build: $(BUILD_ALL_VERSIONS)
 
-test-0.6:
-	@echo "Test 0.6"
-	@docker run --rm phpstan/phpstan:0.6 list
+.PHONY: test $(TEST_ALL_VERSIONS)
+$(TEST_ALL_VERSIONS): test-%:
+	@echo "Test $*"
+	@docker run --rm phpstan/phpstan:$* list
 
-test-latest:
-	@echo "Test dev-master"
-	@docker run --rm phpstan/phpstan:latest list
+test: build $(TEST_ALL_VERSIONS)

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 [![Docker Stars](https://img.shields.io/docker/stars/phpstan/phpstan.svg)](https://hub.docker.com/r/phpstan/phpstan/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/phpstan/phpstan.svg)](https://hub.docker.com/r/phpstan/phpstan/)
 
-The image is based on [Alpine Linux](https://alpinelinux.org/) and built daily. 
+The image is based on [Alpine Linux](https://alpinelinux.org/) and built daily.
 
 ## Supported tags
 
 - `latest` [(latest/Dockerfile)](latest/Dockerfile)
 - `0.6` [(0.6/Dockerfile)](0.6/Dockerfile)
+- `0.7` [(0.7/Dockerfile)](0.7/Dockerfile)
 
 ## How to use this image
 
@@ -37,7 +38,7 @@ To use simply *phpstan* everywhere on CLI add this line to your ~/.zshrc, ~/.bas
 alias phpstan='docker run -v $PWD:/app --rm phpstan/phpstan'
 ```
 
-If you don't have set the alias, use this command to run the container: 
+If you don't have set the alias, use this command to run the container:
 
 ```
 docker run --rm -v /path/to/app:/app phpstan/phpstan [some arguments for PHPStan]
@@ -46,5 +47,5 @@ docker run --rm -v /path/to/app:/app phpstan/phpstan [some arguments for PHPStan
 For example:
 
 ```
-docker run --rm -v /path/to/app:/app phpstan/phpstan analyse /app/src 
+docker run --rm -v /path/to/app:/app phpstan/phpstan analyse /app/src
 ```


### PR DESCRIPTION
Hi.

Thanks for setting this up.

Recently the version 0.7 of phpstan was released so I've added a recipe for that.

Further I've "simplified" the `Makefile` so that there is no duplication.  When new version is added just add it to the list on the first line and it will be picked up automatically.