### PR TITLE
Update phar to latest PHPStan

### DIFF
--- a/phar/Dockerfile
+++ b/phar/Dockerfile
@@ -1,13 +1,13 @@
 FROM php:7.1-alpine
 
-ENV PHPSTAN_VERSION 0.7
+ARG PHPSTAN_VERSION=0.8.4
 
 RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini
 
 RUN apk update --no-cache \
-    && curl -LOs https://github.com/phpstan/phpstan/releases/download/0.7/phpstan-0.7.phar \
-    && chmod +x phpstan-0.7.phar \
-    && mv phpstan-0.7.phar /usr/local/bin/phpstan \
+    && curl -LOs https://github.com/phpstan/phpstan/releases/download/${PHPSTAN_VERSION}/phpstan.phar \
+    && chmod +x phpstan.phar \
+    && mv phpstan.phar /usr/local/bin/phpstan \
     && rm -rf /var/cache/apk/* /var/tmp/* /tmp/*
 
 VOLUME ["/app"]


### PR DESCRIPTION
- Use latest phar release
- Use ARG instead of ENV, so it can be easily overridden in images which inherits from this one or during CLI build (`--build-arg PHPSTAN_VERSION=xxx`)