### PR TITLE
Remove tiki, as it is included in Docker itself

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,6 @@ FROM php:7.1-alpine
 MAINTAINER Tommy Muehle <tommy.muehle@gmail.com>
 
 RUN apk update --no-cache \
-    && apk add --no-cache tini \
     && rm -rf /var/cache/apk/* /var/tmp/* /tmp/*
 
 ENV COMPOSER_HOME /composer
@@ -22,4 +21,4 @@ ENV PATH /composer/vendor/bin:$PATH
 VOLUME ["/app"]
 WORKDIR /app
 
-ENTRYPOINT ["/sbin/tini", "--", "phpstan"]
+ENTRYPOINT ["phpstan"]

--- a/phar/Dockerfile
+++ b/phar/Dockerfile
@@ -5,7 +5,6 @@ ENV PHPSTAN_VERSION 0.7
 RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini
 
 RUN apk update --no-cache \
-    && apk add --no-cache tini \
     && curl -LOs https://github.com/phpstan/phpstan/releases/download/0.7/phpstan-0.7.phar \
     && chmod +x phpstan-0.7.phar \
     && mv phpstan-0.7.phar /usr/local/bin/phpstan \
@@ -14,4 +13,4 @@ RUN apk update --no-cache \
 VOLUME ["/app"]
 WORKDIR /app
 
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/phpstan"]
+ENTRYPOINT ["/usr/local/bin/phpstan"]


### PR DESCRIPTION
Hi,
I suggest removing tini from the build and image, as it is included in Docker  by default since version 1.13  (and its already 8 months since the release, so it could be quite widespread). You just need to start docker run with `--init` flag.

See https://docs.docker.com/engine/reference/run/#specify-an-init-process