### PR TITLE
simplify Dockerfile

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM php:7.3-alpine
 MAINTAINER Tommy Muehle <tommy.muehle@gmail.com>
 
 ENV COMPOSER_HOME /composer
@@ -6,39 +6,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PATH /composer/vendor/bin:$PATH
 ENV PHPSTAN_VERSION 0.10.x
 
-RUN apk --update --progress --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/community add \
-    curl \
-    php7 \
-    php7-ctype \
-    php7-curl \
-    php7-dom \
-    php7-fileinfo \
-    php7-ftp \
-    php7-iconv \
-    php7-json \
-    php7-mbstring \
-    php7-mysqlnd \
-    php7-openssl \
-    php7-pdo \
-    php7-pdo_sqlite \
-    php7-phar \
-    php7-posix \
-    php7-session \
-    php7-simplexml \
-    php7-sqlite3 \
-    php7-tokenizer \
-    php7-xml \
-    php7-xmlreader \
-    php7-xmlwriter \
-    php7-zlib \
-    && curl -o /tmp/composer-setup.php https://getcomposer.org/installer \
-    && curl -o /tmp/composer-setup.sig https://composer.github.io/installer.sig \
-    && php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== trim(file_get_contents('/tmp/composer-setup.sig'))) { echo 'Invalid installer' . PHP_EOL; exit(1); }" \
-    && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer \
-    && php -r "unlink('/tmp/composer-setup.php');" \
-    && php -r "unlink('/tmp/composer-setup.sig');" \
-    && echo "memory_limit=-1" > /etc/php7/conf.d/99_memory-limit.ini \
-    && rm -rf /var/cache/apk/* /var/tmp/* /tmp/*
+COPY --from=composer:1.8.0 /usr/bin/composer /usr/local/bin/composer
 
 RUN composer global require phpstan/phpstan ^0.10 \
     && composer global show | grep phpstan

--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Tommy Muehle <tommy.muehle@gmail.com>
 ENV COMPOSER_HOME /composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PATH /composer/vendor/bin:$PATH
-ENV PHPSTAN_VERSION 0.10.x
+ENV PHPSTAN_VERSION 0.11.x
 
 COPY --from=composer:1.8.0 /usr/bin/composer /usr/local/bin/composer
 


### PR DESCRIPTION
No need to install all the extensions, or are the some of them especially required?

`docker build .` works fine:
```
phpstan/phpdoc-parser          0.3     PHPDoc parser with support for nullable, intersection and generic types
phpstan/phpstan                0.10.7  PHPStan - PHP Static Analysis Tool
Removing intermediate container c5ae76b77f43
 ---> 54dc4aba14bf
Step 9/11 : VOLUME ["/app"]
 ---> Running in 3fc69c2eb7b3
Removing intermediate container 3fc69c2eb7b3
 ---> 7007b5054967
Step 10/11 : WORKDIR /app
 ---> Running in 1fda9ee67479
Removing intermediate container 1fda9ee67479
 ---> a8ff007dceda
Step 11/11 : ENTRYPOINT ["phpstan"]
 ---> Running in b1c48dc07fa1
Removing intermediate container b1c48dc07fa1
 ---> ecd215599575
Successfully built ecd215599575
```