### PR TITLE
Added GD extension

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -14,6 +14,7 @@ RUN apk --update --progress --no-cache --repository http://dl-cdn.alpinelinux.or
     php7-dom \
     php7-fileinfo \
     php7-ftp \
+    php7-gd \
     php7-iconv \
     php7-json \
     php7-mbstring \

--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -13,6 +13,7 @@ RUN apk --update --progress --no-cache --repository http://dl-cdn.alpinelinux.or
     php7-dom \
     php7-fileinfo \
     php7-ftp \
+    php7-gd \
     php7-iconv \
     php7-json \
     php7-mbstring \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -15,6 +15,7 @@ RUN apk --update --progress --no-cache --repository http://dl-cdn.alpinelinux.or
     php7-ftp \
     php7-iconv \
     php7-json \
+    php7-gd \
     php7-mbstring \
     php7-mysqlnd \
     php7-openssl \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -13,6 +13,7 @@ RUN apk --update --progress --no-cache --repository http://dl-cdn.alpinelinux.or
     php7-dom \
     php7-fileinfo \
     php7-ftp \
+    php7-gd \
     php7-iconv \
     php7-json \
     php7-mbstring \

--- a/phar/Dockerfile
+++ b/phar/Dockerfile
@@ -10,6 +10,7 @@ RUN apk --update --progress --no-cache --repository http://dl-cdn.alpinelinux.or
     php7-dom \
     php7-fileinfo \
     php7-ftp \
+    php7-gd \
     php7-iconv \
     php7-json \
     php7-mbstring \


### PR DESCRIPTION
Fixed #31

I have this issue when PHPStan told me that functions like `imagesy` and `imagecreatetruecolor` were not found.

Looking at my composer file, I've forgotten to add `ext-gd` to the requirements (thanks PHPStan ;-) ).

But, after updating my composer file and my project, PHPStan was unable to work (using the Docker image)! Sad story that can be probably be fixed by adding the GD extension to the list of available ones in the official image :+1: 

PS: your tool is awesome :heart: 